### PR TITLE
Fix Spanish localization.

### DIFF
--- a/src/main/resources/assets/butchercraft/lang/es_es.json
+++ b/src/main/resources/assets/butchercraft/lang/es_es.json
@@ -69,7 +69,7 @@
   "butchercraft.advancement.whole_pig.name": "PigGod.",
   "butchercraft.advancement.whole_sheep.desc": "Come todos los artículos comestibles de cordero cocido..",
   "butchercraft.advancement.whole_sheep.name": "beep beep i'm sheep.",
-  "butchercraft.butcherknife.rightclick": "Clic derecho para "acariciar.",
+  "butchercraft.butcherknife.rightclick": "Clic derecho para acariciar.",
   "item.butchercraft.bacon": "Tocino crudo",
   "item.butchercraft.bbq_jar_item": "Salsa barbecue",
   "item.butchercraft.bbq_ribs": "Plato de costillas a la barbacoa",


### PR DESCRIPTION
Hello, I noticed an unescaped quotation mark was causing a JSON syntax error and preventing these entries from loading. After looking more into the context of this sentence I think it was added there in error so I removed it.