### PR TITLE
[fix]Only cancel UseItemEvent.Finish when it is cancelable

### DIFF
--- a/src/main/java/com/lance5057/butchercraft/ButchercraftModEvents.java
+++ b/src/main/java/com/lance5057/butchercraft/ButchercraftModEvents.java
@@ -204,7 +204,9 @@ public class ButchercraftModEvents {
 					event.getEntity().addEffect(new MobEffectInstance(MobEffects.HUNGER, 600));
 				}
 
-				event.setCanceled(true);
+				if (event.isCancelable()) {
+					event.setCanceled(true);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Dirtyhands effect will cause crash when it's trying to cancel the UseItemEvent launched by **Feeding Upgrade** from [Sophisticated Backpacks](https://www.curseforge.com/minecraft/mc-mods/sophisticated-backpacks).

`[04:27:52] [Server thread/ERROR]: Exception caught during firing event: Attempted to call Event#setCanceled() on a non-cancelable event of type: net.minecraftforge.event.entity.living.LivingEntityUseItemEvent.Finish`
full log: https://mclo.gs/GidCjmw

According to [forge's document](https://docs.minecraftforge.net/en/1.20.1/concepts/events/), it's recommend to check if an event is cancelable before cancel an event.
> Not all events can be canceled! Attempting to cancel an event that is not cancelable will result in an unchecked UnsupportedOperationException being thrown, which is expected to result in the game crashing! Always check that an event can be canceled using Event#isCancelable() before attempting to cancel it!

I added isCancelable() check and tested locally, it works well. So I made this PR and hope this can help.