### PR TITLE
fix: run carcass effect logic only on server side

### DIFF
--- a/src/main/java/com/lance5057/butchercraft/items/CarcassItem.java
+++ b/src/main/java/com/lance5057/butchercraft/items/CarcassItem.java
@@ -21,7 +21,7 @@ public class CarcassItem extends Item {
 
 	@Override
 	public void inventoryTick(ItemStack pStack, Level pLevel, Entity pEntity, int pSlotId, boolean pIsSelected) {
-		if (pLevel.getRandom().nextInt() % ButchercraftConfig.CARCASS_EFFECT_CHANCE.get() == 0)
+		if (!pLevel.isClientSide && pLevel.getRandom().nextInt() % ButchercraftConfig.CARCASS_EFFECT_CHANCE.get() == 0)
 			if (pEntity instanceof Player p) {
 				ItemStack boots = p.getInventory().getArmor(0);
 				if (boots.getItem() instanceof BootsItem)


### PR DESCRIPTION
Fix a bug where the server and client are out of sync.

https://github.com/user-attachments/assets/d5558ea6-2b17-4370-bebf-cb2539e4443c