### PR TITLE
fix: correct breaking logic for dummy blocks

### DIFF
--- a/src/main/java/com/lance5057/butchercraft/workstations/butcherblock/ButcherBlockBlock.java
+++ b/src/main/java/com/lance5057/butchercraft/workstations/butcherblock/ButcherBlockBlock.java
@@ -1,5 +1,8 @@
 package com.lance5057.butchercraft.workstations.butcherblock;
 
+import java.util.Collections;
+import java.util.List;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
@@ -25,6 +28,7 @@ import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
+import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
@@ -129,8 +133,11 @@ public class ButcherBlockBlock extends Block implements EntityBlock, SimpleWater
 	}
 
 	void removeAbove(Level level, BlockPos pos) {
-		if (level.getBlockState(pos.above()).getBlock() instanceof ButcherBlockBlock)
-			level.destroyBlock(pos.above(), false);
+		if (level.getBlockState(pos.above()).getBlock() instanceof ButcherBlockBlock) {
+			if (level.getBlockState(pos.above()).getValue(DUMMY)) {
+				level.destroyBlock(pos.above(), false);
+			}
+		}
 	}
 
 	@Override
@@ -151,11 +158,18 @@ public class ButcherBlockBlock extends Block implements EntityBlock, SimpleWater
 	@Override
 	public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving) {
 		if (state.getBlock() != newState.getBlock()) {
-
-			removeAbove(level, pos);
-
+			if (!state.getValue(DUMMY)) {
+				removeAbove(level, pos);
+			}
 			super.onRemove(state, level, pos, newState, isMoving);
 		}
 	}
 
+	@Override
+	public List<ItemStack> getDrops(BlockState state, LootParams.Builder params) {
+		if (state.getValue(DUMMY)) {
+			return Collections.emptyList();
+		}
+		return super.getDrops(state, params);
+	}
 }

--- a/src/main/java/com/lance5057/butchercraft/workstations/hook/MeatHookBlock.java
+++ b/src/main/java/com/lance5057/butchercraft/workstations/hook/MeatHookBlock.java
@@ -1,5 +1,8 @@
 package com.lance5057.butchercraft.workstations.hook;
 
+import java.util.Collections;
+import java.util.List;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
@@ -26,6 +29,7 @@ import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
+import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
@@ -138,10 +142,16 @@ public class MeatHookBlock extends Block implements EntityBlock, SimpleWaterlogg
 	}
 
 	void removeBelow(Level level, BlockPos pos) {
-		if (level.getBlockState(pos.below()).getBlock() instanceof MeatHookBlock)
-			level.destroyBlock(pos.below(), false);
-		if (level.getBlockState(pos.below(2)).getBlock() instanceof MeatHookBlock)
-			level.destroyBlock(pos.below(2), false);
+		if (level.getBlockState(pos.below()).getBlock() instanceof MeatHookBlock) {
+			if (level.getBlockState(pos.below()).getValue(DUMMY) != 0) {
+				level.destroyBlock(pos.below(), false);
+			}
+		}
+		if (level.getBlockState(pos.below(2)).getBlock() instanceof MeatHookBlock) {
+			if (level.getBlockState(pos.below(2)).getValue(DUMMY) != 0) {
+				level.destroyBlock(pos.below(2), false);
+			}
+		}
 	}
 
 	@Override
@@ -176,5 +186,13 @@ public class MeatHookBlock extends Block implements EntityBlock, SimpleWaterlogg
 //		}
 
 		super.onRemove(state, level, pos, newState, isMoving);
+	}
+
+	@Override
+	public List<ItemStack> getDrops(BlockState state, LootParams.Builder params) {
+		if (state.getValue(DUMMY) != 0) {
+			return Collections.emptyList();
+		}
+		return super.getDrops(state, params);
 	}
 }


### PR DESCRIPTION
Fixes #144 

Also fixed an issue where blocks were incorrectly destroyed recursively.

For example, stacking ButcherBlocks vertically along the Y-axis. When the bottom block is broken, it causes all blocks to be destroyed recursively